### PR TITLE
Minor change to support MSVC 2010 compile.

### DIFF
--- a/mc_lexer.l
+++ b/mc_lexer.l
@@ -13,6 +13,9 @@ typedef MC::MC_Parser::token token;
 /* define yyterminate as this instead of NULL */
 #define yyterminate() return(token::END)
 
+/* wamckee 2013 APR 1 - msvc2010 requires that we exclude this header file. */
+#define YY_NO_UNISTD_H
+
 %}
 
 %option debug 


### PR DESCRIPTION
MSVC 2010 does not have the <unistd.h> header file so 
we must tell flex to exclude it. Excluding <unistd.h> on other 
platforms is benign.
