### PR TITLE
Minor bug fix interpreting parse() return value

### DIFF
--- a/mc_driver.cpp
+++ b/mc_driver.cpp
@@ -4,26 +4,40 @@
 
 #include "mc_driver.hpp"
 
-#ifndef FAIL
-#define FAIL -1
+// wamckee 2013 APR 2 - Instead of testing for == FAIL below,
+// we test for != ACCEPT (in which ACCEPT has a value of zero).
+// When compiling on a MSVC 2010 platform using cygwin's Flex and Bison,
+// we note that the return value from parse() is not -1 but rather +1.
+// It is more likely that on different platforms the return value of zero
+// will be used consistantly to indicate an accept state. Whereas, the
+// value of the abort or fail state will be more likely not to be a specific
+// value but rather a value that is not equal to zero.
+
+#ifndef ACCEPT
+#define ACCEPT 0
 #endif
 
 MC::MC_Driver::~MC_Driver(){ 
-   if( scanner != nullptr ) delete(scanner); 
-   if( parser  != nullptr ) delete(parser);
+   delete(scanner);  // wamckee 2013 APR 2
+   delete(parser);   // wamckee 2013 APR 2
 }
 
 void MC::MC_Driver::parse( const char *filename ){
    assert( filename != nullptr );
    std::ifstream in_file( filename );
    if( ! in_file.good() ) exit( EXIT_FAILURE );
+   
+   delete(scanner); // wamckee 2013 APR 2
    scanner = new MC::MC_Scanner( &in_file );
    /* check to see if its initialized */
    assert( scanner != nullptr );
+   
+   delete(parser); // wamckee 2013 APR 2
    parser = new MC::MC_Parser( (*scanner) /* scanner */, 
                                (*this) /* driver */ );
    assert( parser != nullptr );
-   if(parser->parse() == FAIL)
+   
+   if(parser->parse() != ACCEPT) // wamckee 2013 APR 2
    {
       std::cerr << "Parse failed!!\n";
    }


### PR DESCRIPTION
1) Instead of testing for == FAIL below,we test for != ACCEPT (in which ACCEPT has a value of zero). When compiling on a MSVC 2010 platform using cygwin's Flex and Bison,we note that the return value from parse() is not -1 but rather +1. It is more likely that on different platforms the return value of zero will be used consistantly to indicate an accept state. Whereas, the value of the abort or fail state will be more likely not to be a specific value but rather a value that is not equal to zero.

2) The expression:
  if (p != nullptr) delete p;
can be rewritten more concisely
  delete p;
since delete is well behaved when passed a nullptr.

3) One should release the pointer to the old scanner and parser
before allocating a new one. Otherwise, you will have memory leaks
if MC_Driver::parse() is call more than once per instance.
