### PR TITLE
Memory leaks in mc_parser.yy

### DIFF
--- a/mc_parser.yy
+++ b/mc_parser.yy
@@ -45,18 +45,30 @@
 %token <sval> NEWLINE
 %token <sval> CHAR
 
+%type <sval> object
+
+%destructor { delete( $$ ); } UPPER LOWER WORD NEWLINE CHAR
+
 
 %%
-S     :  S UPPER     { driver.add_upper(); }
-      |  S LOWER     { driver.add_lower(); }
-      |  S WORD      { driver.add_word( *$2 ); delete( $2 ); }
-      |  S NEWLINE   { driver.add_newline(); }
-      |  S CHAR      { driver.add_char(); }
-      |  UPPER       { driver.add_upper(); }
-      |  LOWER       { driver.add_lower(); }
-      |  WORD        { driver.add_word( *$1 ); delete( $1 ); }
-      |  NEWLINE     { driver.add_newline(); }
-      |  CHAR        { driver.add_char(); }
+
+list_option : END | list END;
+
+list
+  : object
+  | list object
+  ;
+
+object : item { delete( $$ ); }
+
+item
+  : UPPER   { driver.add_upper(); }
+  | LOWER   { driver.add_lower(); }
+  | WORD    { driver.add_word( *$1 ); }
+  | NEWLINE { driver.add_newline(); }
+  | CHAR    { driver.add_char(); }
+  ;
+
 %%
 
 


### PR DESCRIPTION
I created a fork (inadvertently) with a new grammar / code defined in mc_parser.yy. It fixes a few problems with memory leaks and heap management. If you like the changes, please merge the code.

1) Since we are allocating the token strings on the heap,
we need to tell Bison how to clean up the heap in the event
of an error. We use the %destructor directive for this purpose.

2) We need to manage the heap to prevent memory leaks when
the parser succeeds. Therefore, I have rewritten the grammar and 
I propose we use an intermediate "object" rule to do 
the memory management. This requires the addition of the %type 
directive so the pointers get passed to the object rule correctly.

P.S. I'm new to github so please bear with me. I'm using their web interface right now. I'm not sure about how to merge branches and forks so I'll leave that up to you. Thanks.
