### PR TITLE
Add namespace to yyclass

### DIFF
--- a/mc_lexer.l
+++ b/mc_lexer.l
@@ -20,7 +20,7 @@ typedef MC::MC_Parser::token token;
 
 %option debug 
 %option nodefault 
-%option yyclass="MC_Scanner" 
+%option yyclass="MC::MC_Scanner" 
 %option noyywrap 
 %option c++
 

--- a/mc_scanner.hpp
+++ b/mc_scanner.hpp
@@ -5,9 +5,6 @@
 #include <FlexLexer.h>
 #endif
 
-#undef  YY_DECL
-#define YY_DECL int  MC::MC_Scanner::yylex()
-
 #include "mc_parser.tab.hh"
 
 namespace MC{


### PR DESCRIPTION
Hello,

I was quite puzzled by the undef/define lines. So I did some experiments... and found they aren't mandatory. IMHO the code is better like this ;-)

Cheers
Michel
