### PR TITLE
This will fix small memory leak

### DIFF
--- a/mc_scanner.hpp
+++ b/mc_scanner.hpp
@@ -17,7 +17,10 @@ public:
    {
       loc = new MC::MC_Parser::location_type();
    };
-  
+   virtual ~MC_Scanner() {
+      delete loc;
+   };
+
    //get rid of override virtual function warning
    using FlexLexer::yylex;
 


### PR DESCRIPTION
Thanks for sharing this. Makes adoption of the great tool lot easier in C++.
About the bug:
pointer should be released   when scanner goes out of scope to free previously allocated memory