### PR TITLE
Fixed issue with locations of parse errors

### DIFF
--- a/mc_lexer.l
+++ b/mc_lexer.l
@@ -5,7 +5,7 @@
 /* Implementation of yyFlexScanner */ 
 #include "mc_scanner.hpp"
 #undef  YY_DECL
-#define YY_DECL int MC::MC_Scanner::yylex( MC::MC_Parser::semantic_type * const lval, MC::MC_Parser::location_type *location )
+#define YY_DECL int MC::MC_Scanner::yylex( MC::MC_Parser::semantic_type * const lval, MC::MC_Parser::location_type *loc )
 
 /* typedef to make the returns for the tokens shorter */
 using token = MC::MC_Parser::token;


### PR DESCRIPTION
If you change your grammar in such a way that, for some strange reason,
you want each upper-case letter to be followed by an 'x', the resulting
rules in mc_parser.yy could look like this:

item
  : UPPER 'x' { driver.add_upper(); }
  ...
  ;

Now if your parser encounters an upper-case letter and then a character
that is not 'x', it would report an error. However, the printed location
is always line 1, column 1. The proposed change should fix that.