### PR TITLE
remove unused MC_Scanner::loc

### DIFF
--- a/mc_scanner.hpp
+++ b/mc_scanner.hpp
@@ -15,10 +15,8 @@ public:
    
    MC_Scanner(std::istream *in) : yyFlexLexer(in)
    {
-      loc = new MC::MC_Parser::location_type();
    };
    virtual ~MC_Scanner() {
-      delete loc;
    };
 
    //get rid of override virtual function warning
@@ -34,8 +32,6 @@ public:
 private:
    /* yyval ptr */
    MC::MC_Parser::semantic_type *yylval = nullptr;
-   /* location ptr */
-   MC::MC_Parser::location_type *loc    = nullptr;
 };
 
 } /* end namespace MC */


### PR DESCRIPTION
It looks as if this variable is used, but actually it is not. The #define to
YY_DECL differs from the MC_Scanner::yylex prototype and, as a result, the
second argument to this method shadows the class member. It does not seem as if
any code relies on MC_Scanner::loc existing, so this commit removes it for
clarity.

----

Thanks for this tutorial; very helpful! I'm not sure if the change I've made matches the original intention of the code, but it seems like this class member is not needed.

It's not clear to me whether you need `MC_Scanner::yylval` either as it is only accessed when `lval` is in scope anyway (i.e. within `yylex`).